### PR TITLE
Build and publish linux appimage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 jobs:
   release:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out Git repository
@@ -23,13 +23,22 @@ jobs:
         uses: actions/setup-node@v4.0.3
         with:
           node-version: '20.x'
+      
+      # Needed to build for windows   
+      - name: "Install wine"
+        run: sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install -y wine wine32
 
       - name: Install dependencies
         run: npm install
 
       - name: Build app
         id: build
-        run: npm run build
+        run: npm run build-no-pack
+
+      - name: Package App
+        id: pack
+        # Package for both windows and linux
+        run: npm run electron-pack -- --windows --linux
 
       - name: Attest build
         id: attestation
@@ -42,6 +51,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
+            dist/Trakkr*.AppImage
             dist/Trakkr Setup *.exe
             ${{ steps.attestation.outputs.bundle-path }}
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build && npm run electron-pack",
+    "build-no-pack": "vite build",
     "serve": "vite preview",
     "electron-dev": "electron .",
     "electron-pack": "electron-builder --publish=never",
@@ -47,15 +48,24 @@
     "productName": "Trakkr.",
     "npmRebuild": false,
     "files": [
-      "./dist/**/*",
       "./electron/**/*",
-      "index.html"
+      "index.html",
+      "dist/**/*",
+      "!dist/*-unpacked",
+      "!dist/*.AppImage",
+      "!dist/*.exe"
     ],
     "win": {
       "icon": "./public/icon.ico",
       "target": "nsis"
     },
-    "linux": false,
+    "linux": {
+      "target": [
+        "AppImage"
+      ],
+      "category": "Utility",
+      "icon": "./public/icon.png"
+    },
     "mac": false
   }
 }


### PR DESCRIPTION
Made CI build and publish Linux appimage
Currently the linux build will hang on launch as it cant find the journal folder
The hang occurs in the windows build as well, if the journal folder is missing/somewhere else.
A workaround is to create a link to the journal folder $HOME/Saved Games/Frontier Developments/Elite Dangerous
If Elite is installed on the default drive this command will fix it:
```ln -s "$HOME/.local/share/Steam/steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved Games/Frontier Developments" "$HOME/Saved Games" ```
Probably want to add a way to choose the journal location, however this should be done in a separate PR