### PR TITLE
Fix investment calculation being always 0

### DIFF
--- a/src/components/Config/Config.tsx
+++ b/src/components/Config/Config.tsx
@@ -11,7 +11,7 @@ function Config() {
   const [initialConfig, setInitialConfig]: any = useState({});
 
   const onNameChange = (e: any, oldKey: string) => {
-    const { value: newKey } = e.target;
+    const newKey = e.target.value.toLowerCase();
 
     if (!newKey.trim()) return;
 


### PR DESCRIPTION
The issue was caused by the code looking up the commodity by lowercase name despite it being saved case sensitive 
This changes it to save in lowercase which fixes the issue